### PR TITLE
feat: add OpenAI Compatible provider support

### DIFF
--- a/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Main.cs
+++ b/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Main.cs
@@ -31,6 +31,7 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
         private const string ProviderCohere = "Cohere";
         private const string ProviderGoogle = "Google";
         private const string ProviderOllama = "Ollama";
+        private const string ProviderOpenAICompatible = "OpenAI Compatible";
 
         private const string ProviderOptionKey = "quickai_provider";
         private const string PrimaryKeyOptionKey = "quickai_primary_key";
@@ -59,7 +60,8 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             ProviderOpenRouter,
             ProviderCohere,
             ProviderGoogle,
-            ProviderOllama
+            ProviderOllama,
+            ProviderOpenAICompatible
         };
 
         private static readonly IReadOnlyDictionary<string, ProviderConfiguration> ProviderConfigurations =
@@ -71,7 +73,8 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 [ProviderOpenRouter] = new("https://openrouter.ai/api/v1/chat/completions", ProviderSchemaType.OpenAI),
                 [ProviderCohere] = new("https://api.cohere.com/v1/chat", ProviderSchemaType.Cohere),
                 [ProviderGoogle] = new("https://generativelanguage.googleapis.com/v1beta", ProviderSchemaType.Google),
-                [ProviderOllama] = new("http://localhost:11434/v1/chat/completions", ProviderSchemaType.OpenAI)
+                [ProviderOllama] = new("http://localhost:11434/v1/chat/completions", ProviderSchemaType.OpenAI),
+                [ProviderOpenAICompatible] = new("http://localhost/v1/chat/completions", ProviderSchemaType.OpenAI)
             };
 
         private static readonly HttpClient HttpClient = CreateHttpClient();
@@ -359,8 +362,8 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                         new()
                         {
                             Key = OllamaHostOptionKey,
-                            DisplayLabel = "Ollama Host URL",
-                            DisplayDescription = "Host URL for local Ollama instance (e.g., http://localhost:11434).",
+                            DisplayLabel = "Custom Base URL (Ollama / OpenAI Compatible)",
+                            DisplayDescription = "Base URL (e.g. https://api.deepseek.com or http://localhost:11434).",
                             PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
                             TextValue = _ollamaHost
                         }
@@ -656,7 +659,8 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             string json;
 
             // Override endpoint for Ollama with custom host
-            if (string.Equals(configuration.Provider, ProviderOllama, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(configuration.Provider, ProviderOllama, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(configuration.Provider, ProviderOpenAICompatible, StringComparison.OrdinalIgnoreCase))
             {
                 endpoint = $"{configuration.OllamaHost.TrimEnd('/')}/v1/chat/completions";
             }


### PR DESCRIPTION
## Add OpenAI Compatible Provider Support

### Summary
This PR adds support for generic OpenAI-compatible API providers, allowing users to configure custom base URLs for any service that implements the OpenAI API specification (e.g., DeepSeek, local deployments, etc.).

### Changes
- Add `ProviderOpenAICompatible` to supported providers list
- Rename "Ollama Host URL" setting to "Custom Base URL (Ollama / OpenAI Compatible)"
- Update endpoint building logic to handle both Ollama and OpenAI Compatible providers using custom base URLs
- Maintain backward compatibility with existing Ollama configurations

### Use Case
Many AI services now offer OpenAI-compatible APIs:
- DeepSeek API (`https://api.deepseek.com`)
- Local LLM deployments (vLLM, LocalAI, etc.)
- Other cloud providers with OpenAI-compatible endpoints

Previously, users had to use the Ollama provider option with a workaround. This PR provides a dedicated, clearly-labeled option.

### Configuration Example
1. Select "OpenAI Compatible" as the provider
2. Set Custom Base URL to `https://api.deepseek.com` (or your endpoint)
3. Configure your API key and model name
4. The plugin will automatically append `/v1/chat/completions` to the base URL

### Testing
- ✅ Tested with existing Ollama setup (backward compatible)
- ✅ Verified new OpenAI Compatible provider option appears in settings
- ✅ Confirmed custom base URL formatting works correctly
- ✅ All existing providers continue to function normally

### Backward Compatibility
All existing configurations remain functional. Users with Ollama configured will see the renamed setting but functionality is unchanged.