### PR TITLE
feat: LaTeX rendering, block Markdown, sticky-note window, follow-up chat

### DIFF
--- a/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Community.PowerToys.Run.Plugin.QuickAi.csproj
+++ b/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Community.PowerToys.Run.Plugin.QuickAi.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="9.0.10" />
+    <PackageReference Include="WpfMath" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Main.cs
+++ b/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Main.cs
@@ -25,6 +25,57 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
 {
     public sealed class Main : IPlugin, ISettingProvider, IContextMenu, IDisposable
     {
+        /// <summary>
+        /// Ensures bundled dependencies (WpfMath, XamlMath.Shared) can be resolved from the plugin directory.
+        /// PowerToys Run loads plugins via Assembly.LoadFrom, which does not probe the plugin folder
+        /// for referenced assemblies that are not part of the host's deps.json graph.
+        /// </summary>
+        static Main()
+        {
+            System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += (ctx, name) =>
+            {
+                if (name.Name is not ("WpfMath" or "XamlMath.Shared"))
+                {
+                    return null;
+                }
+
+                try
+                {
+                    // Resolve from the plugin's own directory (where this DLL lives).
+                    var pluginDir = Path.GetDirectoryName(typeof(Main).Assembly.Location);
+                    if (!string.IsNullOrEmpty(pluginDir))
+                    {
+                        var candidate = Path.Combine(pluginDir, name.Name + ".dll");
+                        if (File.Exists(candidate))
+                        {
+                            return ctx.LoadFromAssemblyPath(candidate);
+                        }
+                    }
+
+                    // Fall back to the PowerToys shared-dependency directory (parent of RunPlugins).
+                    if (!string.IsNullOrEmpty(pluginDir))
+                    {
+                        var runPluginsDir = Path.GetDirectoryName(pluginDir.TrimEnd(Path.DirectorySeparatorChar));
+                        var sharedDir = Path.GetDirectoryName(runPluginsDir ?? string.Empty);
+                        if (!string.IsNullOrEmpty(sharedDir))
+                        {
+                            var candidate = Path.Combine(sharedDir, name.Name + ".dll");
+                            if (File.Exists(candidate))
+                            {
+                                return ctx.LoadFromAssemblyPath(candidate);
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // Ignore resolution failures; the default loader will surface the original error.
+                }
+
+                return null;
+            };
+        }
+
         private const string ProviderGroq = "Groq";
         private const string ProviderTogether = "Together";
         private const string ProviderFireworks = "Fireworks";
@@ -496,6 +547,7 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 {
                     _resultsWindow = new ResultsWindow();
                     _resultsWindow.Closed += (_, _) => _resultsWindow = null;
+                    _resultsWindow.FollowUpRequested += AskFollowUp;
                     _resultsWindow.Show();
                 }
                 else
@@ -538,12 +590,43 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             _resultsWindow?.AppendText(text);
         }
 
+        /// <summary>
+        /// Handle a follow-up question submitted from the results window.
+        /// Carries the conversation history into the new request and streams
+        /// the answer into the same window.
+        /// </summary>
+        private void AskFollowUp(string question)
+        {
+            if (string.IsNullOrWhiteSpace(question))
+            {
+                return;
+            }
+
+            lock (_sessionGate)
+            {
+                if (_session is null)
+                {
+                    return;
+                }
+
+                _session.StartFollowUp(question.Trim());
+            }
+
+            // Show the user's question in the window, then let streaming fill in the answer.
+            _resultsWindow?.AppendUserQuestion(question.Trim());
+            _resultsWindow?.SetStatusText(" · Thinking...");
+            _resultsWindow?.SetFollowUpBusy(true);
+            TriggerRefresh(_session?.RawQuery ?? string.Empty);
+        }
+
         // notify window that streaming is complete
         private void NotifyStreamingComplete()
         {
             Application.Current?.Dispatcher?.BeginInvoke(() =>
             {
                 _resultsWindow?.SetStreamingComplete();
+                _resultsWindow?.SetFollowUpBusy(false);
+                _resultsWindow?.SetStatusText(string.Empty);
             });
         }
 
@@ -635,6 +718,8 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                     return;
                 }
 
+                var history = session.SnapshotHistory();
+
                 try
                 {
                     await foreach (var chunk in ExecuteStreamingRequestAsync(
@@ -643,6 +728,7 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                         prompt,
                         candidate.Key,
                         session.ImageBase64,
+                        history,
                         session.Token).ConfigureAwait(false))
                     {
                         session.Append(chunk);
@@ -694,9 +780,10 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             string prompt,
             string apiKey,
             string? imageBase64,
+            IReadOnlyList<(string Role, string Content)>? history,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            using var request = BuildHttpRequest(providerConfiguration, configuration, prompt, apiKey, imageBase64);
+            using var request = BuildHttpRequest(providerConfiguration, configuration, prompt, apiKey, imageBase64, history);
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(TimeSpan.FromSeconds(configuration.TimeoutSeconds));
 
@@ -785,7 +872,8 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             ConfigurationSnapshot configuration,
             string prompt,
             string apiKey,
-            string? imageBase64 = null)
+            string? imageBase64 = null,
+            IReadOnlyList<(string Role, string Content)>? history = null)
         {
             string endpoint = providerConfiguration.Endpoint;
             string json;
@@ -875,6 +963,22 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                     if (hasSystemPrompt)
                     {
                         messages.Add(new { role = "system", content = configuration.SystemPrompt });
+                    }
+
+                    // Conversation history (user/assistant pairs) before the new prompt
+                    if (history is not null)
+                    {
+                        foreach (var (role, content) in history)
+                        {
+                            if (string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase))
+                            {
+                                messages.Add(new { role = "assistant", content });
+                            }
+                            else
+                            {
+                                messages.Add(new { role = "user", content });
+                            }
+                        }
                     }
 
                     // User message with optional image
@@ -1420,6 +1524,9 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             private bool _hasError;
             private bool _completed;
 
+            // Conversation history for follow-up questions: alternating user/assistant turns.
+            private readonly List<(string Role, string Content)> _history = new();
+
             // UI Batching optimization
             private int _chunksSinceLastRefresh = 0;
             private const int ChunksPerRefresh = 3;  // Update UI every 3 chunks
@@ -1504,6 +1611,38 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 _owner.BeginStreaming(this);
             }
 
+            /// <summary>
+            /// Start a follow-up turn: archive the current turn into history,
+            /// adopt the new question as the active prompt, clear the buffer,
+            /// and kick off a fresh streaming request with the full conversation.
+            /// </summary>
+            public void StartFollowUp(string question)
+            {
+                lock (_sync)
+                {
+                    // If the previous turn produced a response, archive it as history.
+                    if (!_completed || _buffer.Length > 0)
+                    {
+                        RecordTurnIntoHistory();
+                    }
+
+                    _prompt = question;
+                    _cts.Cancel();
+                    _cts.Dispose();
+                    _cts = new CancellationTokenSource();
+                    _buffer.Clear();
+                    _status = null;
+                    _hasError = false;
+                    _completed = false;
+
+                    // Reset batching counters
+                    _chunksSinceLastRefresh = 0;
+                    _lastRefreshTime = DateTime.UtcNow;
+                }
+
+                _owner.BeginStreaming(this);
+            }
+
             public void Cancel()
             {
                 lock (_sync)
@@ -1556,6 +1695,7 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 lock (_sync)
                 {
                     _completed = true;
+                    RecordTurnIntoHistory();
                 }
 
                 // Notify window that streaming is complete
@@ -1563,6 +1703,62 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
 
                 // Always refresh UI when completed
                 _owner.TriggerRefresh(RawQuery);
+            }
+
+            /// <summary>
+            /// Record the current prompt/response pair into conversation history
+            /// so follow-up questions can carry context.
+            /// </summary>
+            private void RecordTurnIntoHistory()
+            {
+                if (string.IsNullOrWhiteSpace(_prompt))
+                {
+                    return;
+                }
+
+                var response = _buffer.ToString();
+                if (string.IsNullOrWhiteSpace(response))
+                {
+                    return;
+                }
+
+                // If the last recorded user message equals this prompt, treat it as an
+                // update of the same turn (re-ask) rather than a new turn.
+                if (_history.Count >= 2 &&
+                    _history[^2].Role == "user" &&
+                    string.Equals(_history[^2].Content, _prompt, StringComparison.Ordinal))
+                {
+                    _history[^1] = ("assistant", response);
+                    return;
+                }
+
+                _history.Add(("user", _prompt));
+                _history.Add(("assistant", response));
+            }
+
+            /// <summary>
+            /// Snapshot of the conversation history (user/assistant pairs).
+            /// </summary>
+            public List<(string Role, string Content)> SnapshotHistory()
+            {
+                lock (_sync)
+                {
+                    return new List<(string Role, string Content)>(_history);
+                }
+            }
+
+            /// <summary>
+            /// Whether the session currently has an in-flight request.
+            /// </summary>
+            public bool IsBusy
+            {
+                get
+                {
+                    lock (_sync)
+                    {
+                        return !_completed;
+                    }
+                }
             }
 
             public void SetStatus(string message)

--- a/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/ResultsWindow.xaml
+++ b/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/ResultsWindow.xaml
@@ -1,17 +1,19 @@
 <Window x:Class="Community.PowerToys.Run.Plugin.QuickAI.ResultsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="QuickAI Response"
-        Height="650"
-        Width="850"
-        MinHeight="400"
-        MinWidth="500"
-        WindowStartupLocation="CenterScreen"
-        WindowStyle="SingleBorderWindow"
-        AllowsTransparency="False"
-        Background="#1E1E1E"
+        Title="QuickAI"
+        Height="430"
+        Width="560"
+        MinHeight="240"
+        MinWidth="380"
+        WindowStartupLocation="Manual"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
         Foreground="#E4E4E4"
-        ResizeMode="CanResizeWithGrip">
+        ResizeMode="CanResizeWithGrip"
+        Topmost="True"
+        ShowInTaskbar="False">
     
     <Window.Resources>
         <!-- Dark Theme Colors -->
@@ -32,24 +34,50 @@
         <SolidColorBrush x:Key="LightAccent" Color="#0078D4"/>
         <SolidColorBrush x:Key="LightCodeBackground" Color="#F4F4F4"/>
         
-        <!-- Button Style -->
-        <Style x:Key="ToolbarButtonStyle" TargetType="Button">
+        <!-- Compact Icon Button Style (header close button) -->
+        <Style x:Key="IconButtonStyle" TargetType="Button">
             <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Foreground}"/>
+            <Setter Property="Foreground" Value="#A0A0A0"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="12,8"/>
+            <Setter Property="Width" Value="28"/>
+            <Setter Property="Height" Value="28"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="4">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#3C3C3C"/>
+                                <Setter TargetName="border" Property="Opacity" Value="1"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#505050"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        
+        <!-- Compact Toolbar Button Style -->
+        <Style x:Key="CompactToolbarButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="#A0A0A0"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="8,4"/>
             <Setter Property="Margin" Value="2,0"/>
             <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontSize" Value="11"/>
             <Setter Property="FontFamily" Value="Inter, Segoe UI Variable, Segoe UI"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border x:Name="border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="4"
+                        <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="4"
                                 Padding="{TemplateBinding Padding}">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Border>
@@ -67,116 +95,125 @@
         </Style>
     </Window.Resources>
     
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+    <!-- Outer rounded card with shadow -->
+    <Border x:Name="CardBorder" Margin="12" CornerRadius="10" Background="#1E1E1E"
+            BorderBrush="#3C3C3C" BorderThickness="1">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="24" ShadowDepth="0" Opacity="0.45" Color="#000000"/>
+        </Border.Effect>
         
-        <!-- Header/Toolbar -->
-        <Border Grid.Row="0" 
-                Background="#252526" 
-                BorderBrush="#3C3C3C" 
-                BorderThickness="0,0,0,1"
-                Name="HeaderBorder">
-            <Grid Margin="12,8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                
-                <!-- Title -->
-                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="&#xE8BD;" FontFamily="Segoe MDL2 Assets" FontSize="16" 
-                               VerticalAlignment="Center" Margin="0,0,10,0" Foreground="#0078D4"/>
-                    <TextBlock Text="QuickAI Response" FontSize="14" FontWeight="SemiBold" 
-                               FontFamily="Inter, Segoe UI Variable, Segoe UI"
-                               VerticalAlignment="Center" Name="TitleText"/>
-                    <TextBlock Text=" · Streaming" FontSize="12" Foreground="#A0A0A0" 
-                               FontFamily="Inter, Segoe UI Variable, Segoe UI"
-                               VerticalAlignment="Center" Name="StatusText" Visibility="Collapsed"/>
-                </StackPanel>
-                
-                <!-- Toolbar Buttons -->
-                <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <Button Content="&#xE8C8;  Copy" Style="{StaticResource ToolbarButtonStyle}" 
-                            Name="CopyButton" Click="CopyButton_Click" ToolTip="Copy to clipboard (Ctrl+C)">
-                        <Button.ContentTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="&#xE8C8;" FontFamily="Segoe MDL2 Assets" 
-                                               VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                    <TextBlock Text="Copy" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </Button.ContentTemplate>
-                    </Button>
-                    <Button Style="{StaticResource ToolbarButtonStyle}" 
-                            Name="WrapButton" Click="WrapButton_Click" ToolTip="Toggle word wrap">
-                        <Button.ContentTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="&#xE8B3;" FontFamily="Segoe MDL2 Assets" 
-                                               VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                    <TextBlock Text="Wrap" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </Button.ContentTemplate>
-                    </Button>
-                </StackPanel>
-            </Grid>
-        </Border>
-        
-        <!-- Main Content Area -->
-        <Border Grid.Row="1" Margin="0" Background="#1E1E1E" Name="ContentBorder">
-            <FlowDocumentScrollViewer Name="OutputViewer" 
-                                      Padding="20,16"
-                                      VerticalScrollBarVisibility="Auto"
-                                      HorizontalScrollBarVisibility="Disabled"
-                                      IsToolBarVisible="False"
-                                      Zoom="100">
-                <FlowDocument Name="OutputDocument"
-                              FontFamily="Inter, Segoe UI Variable, Segoe UI"
-                              FontSize="14"
-                              Foreground="#E4E4E4"
-                              Background="Transparent"
-                              PagePadding="0"
-                              TextAlignment="Left"
-                              LineHeight="24">
-                </FlowDocument>
-            </FlowDocumentScrollViewer>
-        </Border>
-        
-        <!-- Footer/Status Bar -->
-        <Border Grid.Row="2" 
-                Background="#252526" 
-                BorderBrush="#3C3C3C" 
-                BorderThickness="0,1,0,0"
-                Name="FooterBorder">
-            <Grid Margin="12,6">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                
-                <TextBlock Grid.Column="0" 
-                           Name="CharCountText" 
-                           Text="0 characters" 
-                           FontSize="11" 
-                           FontFamily="Inter, Segoe UI Variable, Segoe UI"
-                           Foreground="#A0A0A0"
-                           VerticalAlignment="Center"/>
-                
-                <TextBlock Grid.Column="1" 
-                           Text="Ctrl+C to copy · Esc to close" 
-                           FontSize="11" 
-                           FontFamily="Inter, Segoe UI Variable, Segoe UI"
-                           Foreground="#606060"
-                           VerticalAlignment="Center"/>
-            </Grid>
-        </Border>
-    </Grid>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            
+            <!-- Compact Header -->
+            <Border Grid.Row="0" Background="#252526" BorderBrush="#3C3C3C" 
+                    BorderThickness="0,0,0,1" CornerRadius="10,10,0,0" Name="HeaderBorder">
+                <Grid Margin="10,4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <!-- Drag handle area (whole header drags window) -->
+                    <Border Grid.ColumnSpan="3" Background="Transparent" 
+                            MouseLeftButtonDown="Header_MouseLeftButtonDown"/>
+                    
+                    <!-- Title -->
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="&#xE8BD;" FontFamily="Segoe MDL2 Assets" FontSize="12" 
+                                   VerticalAlignment="Center" Margin="0,0,6,0" Foreground="#0078D4"/>
+                        <TextBlock Text="QuickAI" FontSize="12" FontWeight="SemiBold" 
+                                   FontFamily="Inter, Segoe UI Variable, Segoe UI"
+                                   VerticalAlignment="Center" Name="TitleText"/>
+                        <TextBlock Text=" · Streaming" FontSize="11" Foreground="#A0A0A0" 
+                                   FontFamily="Inter, Segoe UI Variable, Segoe UI"
+                                   VerticalAlignment="Center" Name="StatusText" Visibility="Collapsed"/>
+                    </StackPanel>
+                    
+                    <!-- Compact actions: copy + wrap + close -->
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button Style="{StaticResource CompactToolbarButtonStyle}" 
+                                Name="WrapButton" Click="WrapButton_Click" ToolTip="Toggle word wrap"
+                                Content="Wrap"/>
+                        <Button Style="{StaticResource CompactToolbarButtonStyle}" 
+                                Name="CopyButton" Click="CopyButton_Click" ToolTip="Copy to clipboard (Ctrl+C)"
+                                Content="Copy"/>
+                        <Button Style="{StaticResource IconButtonStyle}" 
+                                Name="CloseButton" Click="CloseButton_Click" ToolTip="Close (Esc)"
+                                Content="&#xE8BB;" Margin="4,0,0,0"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+            
+            <!-- Main Content Area (compact padding) -->
+            <Border Grid.Row="1" Margin="0" Background="#1E1E1E" Name="ContentBorder">
+                <FlowDocumentScrollViewer Name="OutputViewer" 
+                                          Padding="12,10"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled"
+                                          IsToolBarVisible="False"
+                                          Zoom="100">
+                    <FlowDocument Name="OutputDocument"
+                                  FontFamily="Inter, Segoe UI Variable, Segoe UI"
+                                  FontSize="13"
+                                  Foreground="#E4E4E4"
+                                  Background="Transparent"
+                                  PagePadding="0"
+                                  TextAlignment="Left"
+                                  LineHeight="21">
+                    </FlowDocument>
+                </FlowDocumentScrollViewer>
+            </Border>
+            
+            <!-- Follow-up Input Area -->
+            <Border Grid.Row="2" Background="#252526" BorderBrush="#3C3C3C"
+                    BorderThickness="0,1,0,0" Name="FollowUpBorder">
+                <Grid Margin="10,6">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <TextBox Grid.Column="0" Name="FollowUpBox"
+                             Height="26"
+                             VerticalContentAlignment="Center"
+                             FontSize="12"
+                             KeyDown="FollowUpBox_KeyDown"
+                             TextChanged="FollowUpBox_TextChanged"
+                             ToolTip="Ask a follow-up (Enter to send)"/>
+                    
+                    <Button Grid.Column="1" 
+                            Name="SendButton" Click="SendButton_Click" ToolTip="Send follow-up (Enter)"
+                            Margin="6,0,0,0" Content="Send" IsEnabled="False"/>
+                </Grid>
+            </Border>
+            
+            <!-- Compact Footer -->
+            <Border Grid.Row="3" Background="#252526" BorderBrush="#3C3C3C" 
+                    BorderThickness="0,1,0,0" CornerRadius="0,0,10,10" Name="FooterBorder">
+                <Grid Margin="10,4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <TextBlock Grid.Column="0" Name="CharCountText" Text="0 characters" 
+                               FontSize="10" FontFamily="Inter, Segoe UI Variable, Segoe UI"
+                               Foreground="#A0A0A0" VerticalAlignment="Center"/>
+                    
+                    <TextBlock Grid.Column="1" Text="Esc close · Ctrl+C copy" 
+                               FontSize="10" FontFamily="Inter, Segoe UI Variable, Segoe UI"
+                               Foreground="#606060" VerticalAlignment="Center"/>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
     
     <Window.InputBindings>
         <KeyBinding Key="C" Modifiers="Control" Command="{x:Static ApplicationCommands.Copy}"/>

--- a/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/ResultsWindow.xaml.cs
+++ b/QuickAi/Community.PowerToys.Run.Plugin.QuickAi/ResultsWindow.xaml.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
@@ -7,12 +8,21 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
+using WpfMath;
+using WpfMath.Controls;
 
 namespace Community.PowerToys.Run.Plugin.QuickAI
 {
     public partial class ResultsWindow : Window
     {
+        /// <summary>Raised when the user submits a follow-up question from the input box.</summary>
+        public event Action<string>? FollowUpRequested;
+
         private readonly StringBuilder _fullText = new();
+        private readonly StringBuilder _pendingText = new();
+        private System.Windows.Threading.DispatcherTimer? _renderTimer;
+        private bool _renderTimerPending;
+        private const int RenderThrottleMs = 220;
         private string _currentTheme = "dark";
         private bool _wordWrapEnabled = true;
 
@@ -39,6 +49,38 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
         {
             InitializeComponent();
             ApplyTheme("dark");
+            PositionAsStickyNote();
+        }
+
+        /// <summary>
+        /// Position the window like a sticky note: bottom-right of the work area,
+        /// with a small offset from the corner.
+        /// </summary>
+        private void PositionAsStickyNote()
+        {
+            try
+            {
+                var wa = SystemParameters.WorkArea;
+                Left = wa.Right - Width - 24;
+                Top = wa.Bottom - Height - 24;
+            }
+            catch
+            {
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            }
+        }
+
+        private void Header_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ButtonState == MouseButtonState.Pressed)
+            {
+                DragMove();
+            }
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
         }
 
         public void AppendText(string text)
@@ -48,13 +90,66 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             Dispatcher.BeginInvoke(() =>
             {
                 _fullText.Append(text);
+                _pendingText.Append(text);
                 StatusText.Visibility = Visibility.Visible;
-                
-                // Re-render the entire document with markdown
-                RenderMarkdown(_fullText.ToString());
+
+                ScheduleRender();
                 UpdateCharCount();
-                ScrollToEnd();
             });
+        }
+
+        /// <summary>
+        /// Throttle re-rendering during streaming: multiple tokens arriving in a
+        /// short window are coalesced into a single full render + scroll.
+        /// </summary>
+        private void ScheduleRender()
+        {
+            if (_renderTimerPending)
+            {
+                return;
+            }
+
+            _renderTimerPending = true;
+
+            if (_renderTimer == null)
+            {
+                _renderTimer = new System.Windows.Threading.DispatcherTimer
+                {
+                    Interval = TimeSpan.FromMilliseconds(RenderThrottleMs)
+                };
+                _renderTimer.Tick += (_, _) =>
+                {
+                    _renderTimer.Stop();
+                    _renderTimerPending = false;
+                    FlushPendingRender();
+                };
+            }
+
+            _renderTimer.Start();
+        }
+
+        private void FlushPendingRender()
+        {
+            if (_pendingText.Length == 0)
+            {
+                return;
+            }
+
+            _pendingText.Clear();
+            RenderMarkdown(_fullText.ToString());
+            ScrollToEnd();
+        }
+
+        private void FlushRenderNow()
+        {
+            if (_renderTimer != null && _renderTimer.IsEnabled)
+            {
+                _renderTimer.Stop();
+                _renderTimerPending = false;
+            }
+            _pendingText.Clear();
+            RenderMarkdown(_fullText.ToString());
+            ScrollToEnd();
         }
 
         public void SetFullText(string text)
@@ -63,9 +158,10 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             {
                 _fullText.Clear();
                 _fullText.Append(text ?? string.Empty);
+                _pendingText.Clear();
                 StatusText.Visibility = Visibility.Collapsed;
                 
-                RenderMarkdown(_fullText.ToString());
+                FlushRenderNow();
                 UpdateCharCount();
             });
         }
@@ -75,6 +171,8 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             Dispatcher.Invoke(() =>
             {
                 StatusText.Visibility = Visibility.Collapsed;
+                // Final flush: render the complete text with full markdown.
+                FlushRenderNow();
             });
         }
 
@@ -88,10 +186,17 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 try
                 {
                     var isDark = theme == "dark";
-                    
-                    // Window background
-                    Background = new SolidColorBrush(isDark ? DarkBackground : LightBackground);
+
+                    // Window background (transparent outer; the card itself carries the theme)
+                    Background = Brushes.Transparent;
                     Foreground = new SolidColorBrush(isDark ? DarkText : LightText);
+
+                    // Card shell
+                    if (CardBorder != null)
+                    {
+                        CardBorder.Background = new SolidColorBrush(isDark ? DarkBackground : LightBackground);
+                        CardBorder.BorderBrush = new SolidColorBrush(isDark ? DarkBorder : LightBorder);
+                    }
 
                     // Header
                     HeaderBorder.Background = new SolidColorBrush(isDark ? DarkSurface : LightSurface);
@@ -110,6 +215,13 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                     FooterBorder.Background = new SolidColorBrush(isDark ? DarkSurface : LightSurface);
                     FooterBorder.BorderBrush = new SolidColorBrush(isDark ? DarkBorder : LightBorder);
                     CharCountText.Foreground = new SolidColorBrush(isDark ? DarkTextSecondary : LightTextSecondary);
+
+                    // Follow-up input area
+                    if (FollowUpBorder != null)
+                    {
+                        FollowUpBorder.Background = new SolidColorBrush(isDark ? DarkSurface : LightSurface);
+                        FollowUpBorder.BorderBrush = new SolidColorBrush(isDark ? DarkBorder : LightBorder);
+                    }
 
                     // Re-render markdown with new theme colors
                     if (_fullText.Length > 0)
@@ -142,7 +254,6 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             var codeBlockPattern = @"```(\w*)\r?\n([\s\S]*?)```";
             var parts = Regex.Split(text, codeBlockPattern);
 
-            var currentPara = new Paragraph { Margin = new Thickness(0, 0, 0, 12) };
             var i = 0;
 
             while (i < parts.Length)
@@ -150,13 +261,6 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 // Check if this part is followed by code block content
                 if (i + 2 < parts.Length && IsCodeBlockLanguage(parts, i))
                 {
-                    // Flush current paragraph if it has content
-                    if (currentPara.Inlines.Count > 0)
-                    {
-                        OutputDocument.Blocks.Add(currentPara);
-                        currentPara = new Paragraph { Margin = new Thickness(0, 0, 0, 12) };
-                    }
-
                     // Parts[i+1] is language, parts[i+2] is code content
                     var language = parts[i + 1];
                     var code = parts[i + 2];
@@ -169,18 +273,9 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                     continue;
                 }
 
-                // Regular text - parse inline markdown
-                var inlines = ParseInlineMarkdown(parts[i], textColor, codeTextColor, codeBgColor);
-                foreach (var inline in inlines)
-                {
-                    currentPara.Inlines.Add(inline);
-                }
+                // Regular text - parse block-level markdown (headings, quotes, lists, hr) + inline
+                ParseBlockMarkdown(parts[i], textColor, codeTextColor, codeBgColor);
                 i++;
-            }
-
-            if (currentPara.Inlines.Count > 0)
-            {
-                OutputDocument.Blocks.Add(currentPara);
             }
 
             // Ensure at least one empty paragraph if no content
@@ -189,6 +284,302 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 OutputDocument.Blocks.Add(new Paragraph());
             }
         }
+
+        /// <summary>
+        /// Parse block-level markdown (headings, blockquotes, lists, horizontal rules)
+        /// and emit the corresponding WPF FlowDocument blocks.
+        /// </summary>
+        private void ParseBlockMarkdown(string text, Color textColor, Color codeTextColor, Color codeBgColor)
+        {
+            var lines = text.Replace("\r\n", "\n").Split('\n');
+            var blocks = new System.Collections.Generic.List<Block>();
+            var paraLines = new System.Collections.Generic.List<string>();
+
+            // Accumulate blockquote lines
+            var quoteLines = new System.Collections.Generic.List<string>();
+            // Accumulate list lines
+            var listLines = new System.Collections.Generic.List<(string Marker, string Content)>();
+            var inList = false;
+
+            // Accumulate table rows
+            var tableRows = new System.Collections.Generic.List<string[]>();
+            var tableAlign = new System.Collections.Generic.List<string>();
+            var inTable = false;
+
+            void FlushTable()
+            {
+                if (tableRows.Count == 0)
+                {
+                    return;
+                }
+
+                // Render the table as a Grid (UIElement) wrapped in a BlockUIContainer so it
+                // hugs its content instead of stretching across the full window width.
+                var grid = new Grid
+                {
+                    Margin = new Thickness(0, 0, 0, 12),
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    SnapsToDevicePixels = true
+                };
+
+                var colCount = tableRows.Max(r => r.Length);
+                for (var c = 0; c < colCount; c++)
+                {
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                }
+                for (var r = 0; r < tableRows.Count; r++)
+                {
+                    grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                }
+
+                var borderBrush = new SolidColorBrush(Color.FromArgb(90, 128, 128, 128));
+                var cellBorder = new SolidColorBrush(Color.FromArgb(50, 128, 128, 128));
+
+                for (var r = 0; r < tableRows.Count; r++)
+                {
+                    var isHeader = r == 0;
+                    var cells = tableRows[r];
+
+                    for (var c = 0; c < cells.Length; c++)
+                    {
+                        var border = new Border
+                        {
+                            BorderBrush = borderBrush,
+                            BorderThickness = new Thickness(1),
+                            Padding = new Thickness(8, 4, 8, 4),
+                            Background = isHeader
+                                ? new SolidColorBrush(Color.FromArgb(25, 128, 128, 128))
+                                : Brushes.Transparent,
+                            Child = new TextBlock
+                            {
+                                TextWrapping = TextWrapping.Wrap,
+                                FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal,
+                                FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable"),
+                                Foreground = new SolidColorBrush(textColor)
+                            }
+                        };
+
+                        var tb = (TextBlock)border.Child;
+                        foreach (var inline in ParseInlineMarkdown(cells[c].Trim(), textColor, codeTextColor, codeBgColor))
+                        {
+                            tb.Inlines.Add(inline);
+                        }
+
+                        Grid.SetRow(border, r);
+                        Grid.SetColumn(border, c);
+                        grid.Children.Add(border);
+                    }
+                }
+
+                blocks.Add(new BlockUIContainer(grid));
+                tableRows.Clear();
+                tableAlign.Clear();
+                inTable = false;
+            }
+
+            void FlushParagraph()
+            {
+                if (paraLines.Count > 0)
+                {
+                    var para = new Paragraph { Margin = new Thickness(0, 0, 0, 12) };
+                    para.Inlines.AddRange(ParseInlineMarkdown(string.Join("\n", paraLines), textColor, codeTextColor, codeBgColor));
+                    blocks.Add(para);
+                    paraLines.Clear();
+                }
+            }
+
+            void FlushQuote()
+            {
+                if (quoteLines.Count > 0)
+                {
+                    var quote = new BlockUIContainer
+                    {
+                        Child = new Border
+                        {
+                            Background = new SolidColorBrush(Color.FromArgb(40, 128, 128, 128)),
+                            BorderBrush = new SolidColorBrush(Color.FromArgb(120, 128, 128, 128)),
+                            BorderThickness = new Thickness(3, 0, 0, 0),
+                            Padding = new Thickness(10, 6, 10, 6),
+                            Margin = new Thickness(0, 0, 0, 12),
+                            CornerRadius = new CornerRadius(0, 4, 4, 0),
+                            Child = new TextBlock
+                            {
+                                TextWrapping = TextWrapping.Wrap,
+                                Foreground = new SolidColorBrush(Color.FromArgb(220, textColor.R, textColor.G, textColor.B)),
+                                Inlines = { }
+                            }
+                        }
+                    };
+
+                    // Build quote content as a TextBlock with parsed inlines
+                    var tb = (TextBlock)((Border)quote.Child).Child;
+                    tb.Inlines.Clear();
+                    foreach (var inline in ParseInlineMarkdown(string.Join("\n", quoteLines), textColor, codeTextColor, codeBgColor))
+                    {
+                        tb.Inlines.Add(inline);
+                    }
+                    blocks.Add(quote);
+                    quoteLines.Clear();
+                }
+            }
+
+            void FlushList()
+            {
+                if (listLines.Count > 0)
+                {
+                    var list = new List
+                    {
+                        MarkerStyle = inList ? TextMarkerStyle.Disc : TextMarkerStyle.Disc,
+                        Margin = new Thickness(0, 0, 0, 12),
+                        Padding = new Thickness(20, 0, 0, 0)
+                    };
+                    foreach (var (marker, content) in listLines)
+                    {
+                        var li = new ListItem
+                        {
+                            Margin = new Thickness(0, 0, 0, 4)
+                        };
+                        var para = new Paragraph();
+                        para.Inlines.AddRange(ParseInlineMarkdown(content, textColor, codeTextColor, codeBgColor));
+                        li.Blocks.Add(para);
+                        list.ListItems.Add(li);
+                    }
+                    blocks.Add(list);
+                    listLines.Clear();
+                }
+            }
+
+            foreach (var rawLine in lines)
+            {
+                var line = rawLine.TrimEnd();
+
+                // Table row: | a | b | ... |
+                if (line.Trim().StartsWith("|") && line.Trim().EndsWith("|") && line.Count(ch => ch == '|') >= 2)
+                {
+                    // Split cells (strip outer pipes, split on unescaped pipes)
+                    var trimmed = line.Trim().TrimStart('|').TrimEnd('|');
+                    var cells = trimmed.Split('|').Select(c => c.Trim()).ToArray();
+
+                    // Separator row: |---|---| -> alignment row, skip but keep table going
+                    if (tableRows.Count == 0 && cells.All(c => Regex.IsMatch(c, @"^:?-{3,}:?$")))
+                    {
+                        tableAlign = cells.Select(c => c.StartsWith(":") ? "left" : c.EndsWith(":") ? "right" : "center").ToList();
+                        inTable = true;
+                        continue;
+                    }
+
+                    // Start a new table if previous content existed
+                    FlushParagraph();
+                    FlushQuote();
+                    FlushList();
+                    inTable = true;
+                    tableRows.Add(cells);
+                    continue;
+                }
+
+                // Table separator row (often has no leading pipe: --- | --- | ---)
+                if (inTable && tableRows.Count >= 1 && Regex.IsMatch(line.Trim(), @"^:?-{3,}:?(?:\s*\|\s*:?-{3,}:?)+$"))
+                {
+                    continue;
+                }
+
+                // Leaving a table: flush it
+                if (inTable && tableRows.Count > 0)
+                {
+                    FlushTable();
+                }
+
+                // Horizontal rule: ---, ***, ___
+                if (Regex.IsMatch(line, @"^\s*(?:-{3,}|\*{3,}|_{3,})\s*$"))
+                {
+                    FlushParagraph();
+                    FlushQuote();
+                    FlushList();
+                    blocks.Add(new BlockUIContainer
+                    {
+                        Child = new Border
+                        {
+                            Height = 1,
+                            Background = new SolidColorBrush(Color.FromArgb(80, 128, 128, 128)),
+                            Margin = new Thickness(0, 4, 0, 12)
+                        }
+                    });
+                    inList = false;
+                    continue;
+                }
+
+                // Heading: #, ##, ### ...
+                var headingMatch = Regex.Match(line, @"^(#{1,6})\s+(.*)$");
+                if (headingMatch.Success)
+                {
+                    FlushParagraph();
+                    FlushQuote();
+                    FlushList();
+                    var level = headingMatch.Groups[1].Value.Length;
+                    var content = headingMatch.Groups[2].Value;
+                    var fontSize = level <= 1 ? 20 : level == 2 ? 17 : level == 3 ? 15 : 13.5;
+                    var heading = new Paragraph
+                    {
+                        FontSize = fontSize,
+                        FontWeight = level <= 3 ? FontWeights.Bold : FontWeights.SemiBold,
+                        Margin = new Thickness(0, level <= 2 ? 10 : 8, 0, 6),
+                        Foreground = new SolidColorBrush(textColor),
+                        FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable")
+                    };
+                    heading.Inlines.AddRange(ParseInlineMarkdown(content, textColor, codeTextColor, codeBgColor));
+                    blocks.Add(heading);
+                    inList = false;
+                    continue;
+                }
+
+                // Blockquote: > ...
+                if (line.StartsWith(">"))
+                {
+                    FlushParagraph();
+                    FlushList();
+                    quoteLines.Add(line.TrimStart('>').Trim());
+                    inList = false;
+                    continue;
+                }
+
+                // Unordered list: - , * , + followed by space
+                var ulMatch = Regex.Match(line, @"^\s*[-*+]\s+(.*)$");
+                // Ordered list: 1. , 2. etc.
+                var olMatch = Regex.Match(line, @"^\s*(\d+)\.\s+(.*)$");
+                if (ulMatch.Success || olMatch.Success)
+                {
+                    FlushParagraph();
+                    FlushQuote();
+                    inList = true;
+                    listLines.Add((ulMatch.Success ? "•" : $"{olMatch.Groups[1].Value}.", ulMatch.Success ? ulMatch.Groups[1].Value : olMatch.Groups[2].Value));
+                    continue;
+                }
+
+                // Blank line separates blocks
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    FlushParagraph();
+                    FlushQuote();
+                    FlushList();
+                    inList = false;
+                    continue;
+                }
+
+                // Regular text: accumulate into current paragraph
+                paraLines.Add(line);
+            }
+
+            FlushParagraph();
+            FlushQuote();
+            FlushList();
+            FlushTable();
+
+            foreach (var block in blocks)
+            {
+                OutputDocument.Blocks.Add(block);
+            }
+        }
+
 
         private static bool IsCodeBlockLanguage(string[] parts, int index)
         {
@@ -242,8 +633,9 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
         {
             var inlines = new System.Collections.Generic.List<Inline>();
 
-            // Pattern matches: **bold**, *italic*, `code`, __bold__, _italic_
-            var pattern = @"(\*\*(.+?)\*\*)|(__(.+?)__)|(\*(.+?)\*)|(_([^_]+)_)|(`([^`]+)`)";
+            // Pattern matches: **bold**, *italic*, `code`, __bold__, _italic_, and LaTeX math: \(...\), \[...\], $...$, $$...$$
+            // Math must be matched BEFORE regular markdown to avoid conflicts
+            var pattern = @"(\$\$([\s\S]+?)\$\$)|(\\(?:\[|\()([\s\S]+?)\\(?:\]|\)))|(\$([^\s$][^$]*?)\$)|(\*\*(.+?)\*\*)|(__(.+?)__)|(\*(.+?)\*)|(_([^_]+)_)|(`([^`]+)`)";
             var lastIndex = 0;
 
             foreach (Match match in Regex.Matches(text, pattern))
@@ -256,37 +648,64 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 }
 
                 // Determine match type and create inline
-                if (match.Groups[2].Success) // **bold**
+                if (match.Groups[2].Success) // $$...$$ display math
                 {
-                    inlines.Add(new Bold(new System.Windows.Documents.Run(match.Groups[2].Value))
+                    var math = CreateMathInline(match.Groups[2].Value, textColor);
+                    if (math != null) inlines.Add(math);
+                }
+                else if (match.Groups[4].Success) // \(...\) or \[...\]
+                {
+                    var math = CreateMathInline(match.Groups[4].Value, textColor);
+                    if (math != null) inlines.Add(math);
+                }
+                else if (match.Groups[6].Success) // $...$ inline math
+                {
+                    var math = CreateMathInline(match.Groups[6].Value, textColor);
+                    if (math != null) inlines.Add(math);
+                }
+                else if (match.Groups[8].Success) // **bold**
+                {
+                    inlines.Add(new Bold(new System.Windows.Documents.Run(match.Groups[8].Value)
+                    {
+                        FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable")
+                    })
                     {
                         Foreground = new SolidColorBrush(textColor)
                     });
                 }
-                else if (match.Groups[4].Success) // __bold__
+                else if (match.Groups[10].Success) // __bold__
                 {
-                    inlines.Add(new Bold(new System.Windows.Documents.Run(match.Groups[4].Value))
+                    inlines.Add(new Bold(new System.Windows.Documents.Run(match.Groups[10].Value)
+                    {
+                        FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable")
+                    })
                     {
                         Foreground = new SolidColorBrush(textColor)
                     });
                 }
-                else if (match.Groups[6].Success) // *italic*
+                else if (match.Groups[12].Success) // *italic*
                 {
-                    inlines.Add(new Italic(new System.Windows.Documents.Run(match.Groups[6].Value))
+                    inlines.Add(new Italic(new System.Windows.Documents.Run(match.Groups[12].Value)
+                    {
+                        FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable")
+                    })
                     {
                         Foreground = new SolidColorBrush(textColor)
                     });
                 }
-                else if (match.Groups[8].Success) // _italic_
+                else if (match.Groups[14].Success) // _italic_
                 {
-                    inlines.Add(new Italic(new System.Windows.Documents.Run(match.Groups[8].Value))
+                    inlines.Add(new Italic(new System.Windows.Documents.Run(match.Groups[14].Value)
+                    {
+                        FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable")
+                    })
                     {
                         Foreground = new SolidColorBrush(textColor)
                     });
                 }
-                else if (match.Groups[10].Success) // `code`
+                else if (match.Groups[16].Success) // `code`
                 {
-                    var codeRun = new System.Windows.Documents.Run(match.Groups[10].Value)
+                    var codeRun = new System.Windows.Documents.Run(match.Groups[16].Value)
                     {
                         FontFamily = new FontFamily("JetBrains Mono, Cascadia Code, Consolas, Courier New"),
                         Foreground = new SolidColorBrush(codeTextColor),
@@ -308,6 +727,113 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
             return inlines.ToArray();
         }
 
+        /// <summary>
+        /// Create a WPF inline element that renders a LaTeX formula using WpfMath.
+        /// </summary>
+        private Inline? CreateMathInline(string latex, Color textColor)
+        {
+            var original = latex.Trim();
+            if (string.IsNullOrEmpty(original))
+            {
+                return new System.Windows.Documents.Run(string.Empty);
+            }
+
+            // Clean up LaTeX that WpfMath can't handle but is common in LLM output.
+            var cleaned = SanitizeLatex(original);
+
+            try
+            {
+                // Validate BEFORE rendering: WpfMath renders an error placeholder (red dot)
+                // instead of throwing when parsing fails, so pre-parse to detect problems.
+                var parser = WpfMath.Parsers.WpfTeXFormulaParser.Instance;
+                parser.Parse(cleaned, null);
+
+                var control = new FormulaControl
+                {
+                    Formula = cleaned,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(2, 0, 2, 0),
+                    Foreground = new SolidColorBrush(textColor),
+                    FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable"),
+                    FontSize = 10
+                };
+
+                // Some failures slip past Parse() but surface as an error state when
+                // the control renders (red dot). Detect that and fall back to raw text.
+                if (control.HasError)
+                {
+                    return new System.Windows.Documents.Run(original);
+                }
+
+                return new InlineUIContainer(control)
+                {
+                    BaselineAlignment = BaselineAlignment.Center
+                };
+            }
+            catch (Exception)
+            {
+                // If LaTeX parsing fails, fall back to showing the raw text (no red dot).
+                return new System.Windows.Documents.Run(original);
+            }
+        }
+
+        /// <summary>
+        /// Rewrite common LaTeX constructs that WpfMath (xaml-math) cannot render
+        /// into equivalent forms it understands, or strip unsupported noise.
+        /// </summary>
+        private static string SanitizeLatex(string latex)
+        {
+            var s = latex;
+
+            // \begin{...} ... \end{...} environments: strip wrappers, keep inner content.
+            // WpfMath does not support environments like align/array/cases; the inner
+            // math (often with \\ line breaks) still renders as a formula body.
+            s = Regex.Replace(s, @"\\begin\{(align\*?|aligned\*?|array\*?|cases\*?|matrix\*?|pmatrix\*?|bmatrix\*?|vmatrix\*?|equation\*?|gather\*?|split\*?|multline\*?|tabular\*?|center\*?)\*?\}", "");
+            s = Regex.Replace(s, @"\\end\{(align\*?|aligned\*?|array\*?|cases\*?|matrix\*?|pmatrix\*?|bmatrix\*?|vmatrix\*?|equation\*?|gather\*?|split\*?|multline\*?|tabular\*?|center\*?)\*?\}", "");
+            s = Regex.Replace(s, @"\\begin\{.*?\}", "");
+            s = Regex.Replace(s, @"\\end\{.*?\}", "");
+
+            // \operatorname{...}: WpfMath doesn't support it; convert to \mathrm{...}
+            s = Regex.Replace(s, @"\\operatorname\*?\{([^{}]*?)\}\s*", m => "\\mathrm{" + m.Groups[1].Value + "}");
+
+            // Unsupported multi-letter operator commands (\arccot, \arcsinh, ...): map to \operatorname-equivalent \mathrm{}
+            s = Regex.Replace(s, @"\\(arccot|arcsec|arccsc|arcsinh|arccosh|arctanh|coth|sech|csch|sgn|argmax|argmin|diag|bmod|pmod)\b", m => "\\mathrm{" + m.Groups[1].Value + "}");
+
+            // \text{...} with CJK/non-math content: WpfMath can't render text mode well.
+            // Replace \text{...} with the content wrapped in \mathrm{} (renders as upright text).
+            s = Regex.Replace(s, @"\\text\{([^{}]*?)\}\s*", m => "\\mathrm{" + m.Groups[1].Value + "}");
+            s = Regex.Replace(s, @"\\textnormal\{([^{}]*?)\}\s*", m => "\\mathrm{" + m.Groups[1].Value + "}");
+            s = Regex.Replace(s, @"\\textrm\{([^{}]*?)\}\s*", m => "\\mathrm{" + m.Groups[1].Value + "}");
+
+            // \left. and \right. (invisible delimiters): WpfMath may choke; drop them.
+            s = s.Replace("\\left.", "").Replace("\\right.", "");
+
+            // \displaystyle / \textstyle hints: remove.
+            s = s.Replace("\\displaystyle", "").Replace("\\textstyle", "");
+
+            // \hspace / \vspace / \quad noise: keep \quad (renders as space), drop hspace/vspace.
+            s = Regex.Replace(s, @"\\hspace\{[^}]*\}", " ");
+            s = Regex.Replace(s, @"\\vspace\{[^}]*\}", " ");
+
+            // Unsupported color commands.
+            s = Regex.Replace(s, @"\\color\{[^}]*\}", "");
+            s = Regex.Replace(s, @"\\textcolor\{[^}]*\}\{([^{}]*?)\}", m => m.Groups[1].Value);
+
+            // \n (newline) / double backslash line breaks inside math: convert to spaces.
+            s = s.Replace("\\\\", " ").Replace("\\n", " ");
+
+            // Common commands WpfMath doesn't know: \tag, \label, \nonumber, \notag, \hline
+            s = Regex.Replace(s, @"\\tag\{[^}]*\}", "");
+            s = Regex.Replace(s, @"\\label\{[^}]*\}", "");
+            s = Regex.Replace(s, @"\\nonumber", "").Replace("\\notag", "");
+            s = s.Replace("\\hline", " ");
+
+            // \degree / \textdegree / \deg
+            s = s.Replace("\\degree", "^\\circ").Replace("\\textdegree", "^\\circ");
+
+            return s.Trim();
+        }
+
         private Inline[] ParseNewlines(string text, Color textColor)
         {
             var inlines = new System.Collections.Generic.List<Inline>();
@@ -321,7 +847,11 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
                 }
                 if (!string.IsNullOrEmpty(lines[i]))
                 {
-                    inlines.Add(new System.Windows.Documents.Run(lines[i]) { Foreground = new SolidColorBrush(textColor) });
+                    inlines.Add(new System.Windows.Documents.Run(lines[i])
+                    {
+                        Foreground = new SolidColorBrush(textColor),
+                        FontFamily = new FontFamily("Segoe UI, Inter, Segoe UI Variable")
+                    });
                 }
             }
 
@@ -337,13 +867,120 @@ namespace Community.PowerToys.Run.Plugin.QuickAI
         {
             try
             {
-                var last = OutputViewer.Document?.Blocks.LastBlock;
-                last?.BringIntoView();
+                var doc = OutputViewer?.Document;
+                var last = doc?.Blocks.LastBlock;
+                if (last != null)
+                {
+                    // Scroll the last block into view (WPF FlowDocument pattern)
+                    last.BringIntoView();
+                }
             }
             catch
             {
                 // Ignore scroll errors
             }
+        }
+
+        private void FollowUpBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter && !string.IsNullOrWhiteSpace(FollowUpBox.Text))
+            {
+                e.Handled = true;
+                SubmitFollowUp();
+            }
+        }
+
+        private void SendButton_Click(object sender, RoutedEventArgs e)
+        {
+            SubmitFollowUp();
+        }
+
+        private void FollowUpBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            SendButton.IsEnabled = !string.IsNullOrWhiteSpace(FollowUpBox.Text);
+        }
+
+        private void SubmitFollowUp()
+        {
+            var question = FollowUpBox.Text.Trim();
+            if (string.IsNullOrEmpty(question))
+            {
+                return;
+            }
+
+            FollowUpBox.Text = string.Empty;
+            SendButton.IsEnabled = false;
+            FollowUpRequested?.Invoke(question);
+        }
+
+        /// <summary>
+        /// Append a user question into the document as a distinct "You" block,
+        /// then re-render. Keeps the conversation visible in the sticky note.
+        /// </summary>
+        public void AppendUserQuestion(string question)
+        {
+            if (string.IsNullOrEmpty(question)) return;
+
+            Dispatcher.Invoke(() =>
+            {
+                var isDark = _currentTheme == "dark";
+                var qColor = isDark ? DarkAccent : LightAccent;
+                var accentText = isDark ? DarkTextSecondary : LightTextSecondary;
+
+                // Question marker + text
+                var paragraph = new Paragraph
+                {
+                    Margin = new Thickness(0, 6, 0, 2),
+                    FontFamily = new FontFamily("Inter, Segoe UI Variable, Segoe UI")
+                };
+                paragraph.Inlines.Add(new System.Windows.Documents.Run("❓ ")
+                {
+                    FontSize = 12,
+                    Foreground = new SolidColorBrush(qColor)
+                });
+                paragraph.Inlines.Add(new System.Windows.Documents.Run(question)
+                {
+                    FontSize = 13,
+                    FontWeight = FontWeights.SemiBold,
+                    Foreground = new SolidColorBrush(accentText)
+                });
+
+                OutputDocument.Blocks.Add(paragraph);
+
+                // Divider between turns (a thin bordered paragraph)
+                OutputDocument.Blocks.Add(new Paragraph
+                {
+                    Margin = new Thickness(0, 4, 0, 6),
+                    BorderBrush = new SolidColorBrush(isDark ? DarkBorder : LightBorder),
+                    BorderThickness = new Thickness(0, 0, 0, 1),
+                    Padding = new Thickness(0)
+                });
+
+                ScrollToEnd();
+            });
+        }
+
+        public void SetFollowUpBusy(bool busy)
+        {
+            Dispatcher.BeginInvoke(() =>
+            {
+                SendButton.IsEnabled = !busy && !string.IsNullOrWhiteSpace(FollowUpBox.Text);
+                FollowUpBox.IsEnabled = !busy;
+                StatusText.Visibility = busy ? Visibility.Visible : Visibility.Collapsed;
+                if (busy)
+                {
+                    StatusText.Text = " · Thinking...";
+                }
+            });
+        }
+
+        public void SetStatusText(string text)
+        {
+            Dispatcher.BeginInvoke(() =>
+            {
+                StatusText.Text = text;
+                StatusText.Visibility = string.IsNullOrEmpty(text) ? Visibility.Collapsed : Visibility.Visible;
+            });
         }
 
         private void CopyButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

Adds rich rendering to the QuickAI result window:

- **LaTeX formulas** rendered with WpfMath 2.1.0: `$$...$$`, `\(...\)`, `\[...\]`, `$...$`
- **Block Markdown**: headings (# to ######), blockquotes, ordered/unordered lists, tables, horizontal dividers
- **Sticky-note window**: compact card (560×430), always on top, draggable via top bar
- **Follow-up chat**: input box at the bottom, conversation history kept for multi-turn context
- **Dependency fix**: `AssemblyLoadContext.Default.Resolving` fallback so WpfMath loads from the plugin directory (PowerToys Run does not probe plugin folders for non-host deps)
- **LaTeX sanitization**: strips unsupported environments (`\begin{align}`, `\text{}`, `\left.`, etc.) to avoid red-dot placeholder rendering

## Changes

- `QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Main.cs` — assembly resolution, follow-up API, history
- `QuickAi/Community.PowerToys.Run.Plugin.QuickAi/ResultsWindow.xaml` — sticky-note layout + follow-up input
- `QuickAi/Community.PowerToys.Run.Plugin.QuickAi/ResultsWindow.xaml.cs` — markdown/LaTeX parsing, throttled streaming render
- `QuickAi/Community.PowerToys.Run.Plugin.QuickAi/Community.PowerToys.Run.Plugin.QuickAi.csproj` — adds WpfMath 2.1.0

## Notes

- WpfMath.dll / XamlMath.Shared.dll need to ship alongside the plugin DLL (they are resolved from the plugin directory at runtime).
- Tested on PowerToys 0.100.2.0 with .NET SDK 9.0.317.

Happy to adjust anything the maintainer prefers.