### PR TITLE
fix: build workflow trigger from push:tags to release:published

### DIFF
--- a/.github/workflows/build-and-release-optimized.yml
+++ b/.github/workflows/build-and-release-optimized.yml
@@ -1,9 +1,8 @@
 name: Build and Release QuickAi Plugin (Optimized)
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch: # Allow manual trigger for testing
 
 # Permissions for GITHUB_TOKEN (principle of least privilege)
@@ -168,7 +167,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && github.event.action == 'published' 
 
     steps:
       # OPTIMIZATION: Minimal checkout for release notes only
@@ -183,7 +182,14 @@ jobs:
       # OPTIMIZATION: Fast version extraction with bash
       - name: Extract version
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${GITHUB_REF}" ]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          elif [ -n "${GITHUB_EVENT_NAME}" ] && [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            echo "VERSION=${GITHUB_EVENT_RELEASE_TAG_NAME#v}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=unknown" >> $GITHUB_OUTPUT
+          fi
 
       # OPTIMIZATION: Download artifacts with merge for faster processing
       - name: Download artifacts


### PR DESCRIPTION
## Fixes #28

**Root cause:** `release-please` creates the `v1.3.0` tag using `GITHUB_TOKEN`. Per GitHub security, workflow runs triggered by `GITHUB_TOKEN` do NOT cascade to other workflows — so the `push: tags: [v*]` trigger in `build-and-release-optimized.yml` never fired.

**Fix:** Changed trigger from `push: tags: [v*]` to `release: types: [published]`. Release events DO cascade.

**Changes:**
- Trigger: `push:tags` → `release:published`
- Release job `if` condition updated
- Version extraction handles both tag push and release event contexts

This ensures future releases (v1.4.0+) will automatically build and attach binaries. For v1.3.0, a manual `workflow_dispatch` run for the existing tag can publish the missing assets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-quickai/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->